### PR TITLE
Voice FFT

### DIFF
--- a/Loom.jucer
+++ b/Loom.jucer
@@ -72,6 +72,10 @@
             file="Source/SoundInterface.cpp"/>
       <FILE id="g0Ze7q" name="SoundInterface.h" compile="0" resource="0"
             file="Source/SoundInterface.h"/>
+      <FILE id="zDZQOP" name="SoundInterfaceManager.cpp" compile="1" resource="0"
+            file="Source/SoundInterfaceManager.cpp"/>
+      <FILE id="Pn9jnA" name="SoundInterfaceManager.h" compile="0" resource="0"
+            file="Source/SoundInterfaceManager.h"/>
       <FILE id="sJO8Fl" name="ParameterManager.cpp" compile="1" resource="0"
             file="Source/ParameterManager.cpp"/>
       <FILE id="eW27Uk" name="ParameterManager.h" compile="0" resource="0"

--- a/Source/AnalysisMrs.cpp
+++ b/Source/AnalysisMrs.cpp
@@ -28,33 +28,7 @@ AnalysisMrs::AnalysisMrs(File input, AnalysisParameterManager& params) :
 AnalysisMrs::~AnalysisMrs() {}
 
 
-// Get a new wave file and run sinusoidal analysis
-void AnalysisMrs::newAnalysis()
-{
-    // Get new audio file
-    FileChooser chooser ("Choose audio file ...",
-                         File::nonexistent,
-                         "*.wav");
-    
-    String fileName;
-    if(chooser.browseForFileToOpen())
-    {
-        File file(chooser.getResult());
-        fileName = file.getFullPathName();
-    }
-    else
-    {
-        return;
-    }
-    
-    // Run sineusoidal analysis
-    analysisModel_ = new SineModel();
-    peakDetection(analysisModel_, fileName);
-    sineTracking(analysisModel_);
-    cleanModel(analysisModel_);
-}
-
-SineModel* AnalysisMrs::runAnalysis()
+SineModel::Ptr AnalysisMrs::runAnalysis()
 {
     const String fileName = audioFile.getFullPathName();
     SineModel::Ptr model = new SineModel;

--- a/Source/AnalysisMrs.h
+++ b/Source/AnalysisMrs.h
@@ -41,14 +41,12 @@ public:
     // !! Not responsible for cleaning up the object !!
     SineModel* runAnalysis();
     
-    const SineModel& getAnalysisModel() const { return _analysisModel; };
-    
 private:
-    void peakDetection(SineModel&, String);
-    void sineTracking(SineModel&);
-    void cleanModel(SineModel&);
+    void peakDetection(SineModel::Ptr, String);
+    void sineTracking(SineModel::Ptr);
+    void cleanModel(SineModel::Ptr);
     
-    SineModel _analysisModel;
+    SineModel::Ptr analysisModel_;
     
     File audioFile;
     

--- a/Source/AnalysisMrs.h
+++ b/Source/AnalysisMrs.h
@@ -33,20 +33,14 @@ public:
     // Default Deconstructor
     ~AnalysisMrs();
     
-    // Asks for an audio file and runs analysis on the file, storing the results
-    // in the member analysis model
-    void newAnalysis();
-    
     // Run analysis on file, return a pointer to the created model object
     // !! Not responsible for cleaning up the object !!
-    SineModel* runAnalysis();
+    SineModel::Ptr runAnalysis();
     
 private:
     void peakDetection(SineModel::Ptr, String);
     void sineTracking(SineModel::Ptr);
     void cleanModel(SineModel::Ptr);
-    
-    SineModel::Ptr analysisModel_;
     
     File audioFile;
     

--- a/Source/LoadComponent.cpp
+++ b/Source/LoadComponent.cpp
@@ -12,7 +12,7 @@
 #include "LoadComponent.h"
 
 //==============================================================================
-LoadComponent::LoadComponent(ButtonListener* parent, ActionListener* parentAction, SoundInterface& s) :
+LoadComponent::LoadComponent(ButtonListener* parent, ActionListener* parentAction, SoundInterface* s) :
     soundInterface(s), loomFileDrop(this, s)
 {
     setLookAndFeel(&loomLookAndFeel);

--- a/Source/LoadComponent.h
+++ b/Source/LoadComponent.h
@@ -22,7 +22,7 @@
 class LoadComponent    : public Component, public ActionListener
 {
 public:
-    LoadComponent(ButtonListener* parent, ActionListener* parentAction, SoundInterface& s);
+    LoadComponent(ButtonListener* parent, ActionListener* parentAction, SoundInterface* s);
     ~LoadComponent();
 
     void paint (Graphics&) override;
@@ -37,7 +37,7 @@ private:
 
     
     // Sound interface for this loading component
-    SoundInterface& soundInterface;
+    SoundInterface* soundInterface;
     
     // File drop component
     LoomFileDrop loomFileDrop;

--- a/Source/LoomFileDrop.cpp
+++ b/Source/LoomFileDrop.cpp
@@ -12,7 +12,7 @@
 #include "LoomFileDrop.h"
 
 //==============================================================================
-LoomFileDrop::LoomFileDrop(ActionListener* parent, SoundInterface& s) :
+LoomFileDrop::LoomFileDrop(ActionListener* parent, SoundInterface* s) :
     buttonEdgeColour(Colour::fromRGB(124, 141, 165)), soundInterface(s)
 {
     broadcaster.removeAllActionListeners();
@@ -44,12 +44,12 @@ bool LoomFileDrop::isInterestedInFileDrag(const juce::StringArray &files)
         return false;
     }
     
-    return soundInterface.willAcceptFile(files[0]);
+    return soundInterface->willAcceptFile(files[0]);
 }
 
 void LoomFileDrop::filesDropped(const juce::StringArray &files, int x, int y)
 {
-    soundInterface.loadFile(files[0]);
+    soundInterface->loadFile(files[0]);
     broadcaster.sendActionMessage("reload_state");
 }
 

--- a/Source/LoomFileDrop.h
+++ b/Source/LoomFileDrop.h
@@ -23,7 +23,7 @@ class LoomFileDrop    : public Component,
                         public ActionListener
 {
 public:
-    LoomFileDrop(ActionListener* parent, SoundInterface& s);
+    LoomFileDrop(ActionListener* parent, SoundInterface* s);
     ~LoomFileDrop();
 
     void paint (Graphics&) override;
@@ -41,7 +41,7 @@ private:
     
     Colour buttonEdgeColour;
     
-    SoundInterface& soundInterface;
+    SoundInterface* soundInterface;
     
     
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR (LoomFileDrop)

--- a/Source/PluginEditor.cpp
+++ b/Source/PluginEditor.cpp
@@ -16,7 +16,7 @@
 //==============================================================================
 LoomAudioProcessorEditor::LoomAudioProcessorEditor (LoomAudioProcessor& p) :
     AudioProcessorEditor (&p), processor (p), soundInterface(p.getCurrentSound()),
-    analysisComponent(this, soundInterface.getAnalysisParams()),
+    analysisComponent(this, soundInterface->getAnalysisParams()),
     loadComponent(this, this, soundInterface), synthesisComponent(this)
 {
     setLookAndFeel(&loomLookAndFeel);
@@ -86,14 +86,14 @@ void LoomAudioProcessorEditor::buttonClicked(Button* button)
     
     if (button->getComponentID() == "load_file")
     {
-        soundInterface.loadFile();
+        soundInterface->loadFile();
         loadState();
     }
     
     if (button->getComponentID() == "run_analysis")
     {
-        soundInterface.runAnalysis();
-        processor.swapSound(soundInterface);
+        soundInterface->runAnalysis();
+        //processor.swapSound(soundInterface);
         switchState(SoundInterface::synthesisState);
     }
     
@@ -106,9 +106,9 @@ void LoomAudioProcessorEditor::buttonClicked(Button* button)
 
 void LoomAudioProcessorEditor::switchState(SoundInterface::State newState)
 {
-    if (soundInterface.getState() != newState)
+    if (soundInterface->getState() != newState)
     {
-        soundInterface.setState(newState);
+        soundInterface->setState(newState);
         loadState();
     }
 }
@@ -125,7 +125,7 @@ void LoomAudioProcessorEditor::hideMiddle()
 void LoomAudioProcessorEditor::loadState()
 {
     hideMiddle();
-    switch(soundInterface.getState())
+    switch(soundInterface->getState())
     {
         case SoundInterface::loadFileState:
             loadComponent.setVisible(true);

--- a/Source/PluginEditor.h
+++ b/Source/PluginEditor.h
@@ -20,6 +20,7 @@
 #include "AnalysisComponent.h"
 #include "LoadComponent.h"
 #include "SynthesisComponent.h"
+#include "SoundInterfaceManager.h"
 
 
 //==============================================================================
@@ -74,8 +75,11 @@ private:
     // File Loader
     FileLoader fileLoader;
     
+    
+    //SoundInterfaceManager& soundInterfaceManager;
+    
     // For interfacing with analysis and sounds
-    SoundInterface& soundInterface;
+    SoundInterface* soundInterface;
     
     // This is where analysis and synthesis params go
     AnalysisComponent analysisComponent;

--- a/Source/PluginProcessor.cpp
+++ b/Source/PluginProcessor.cpp
@@ -33,10 +33,13 @@ LoomAudioProcessor::LoomAudioProcessor()
     for (int i = 0; i < maxVoices; ++i)
         synth_.addVoice (new SinusoidalSynthVoice());
 
-    
-    
     // Create the sound manager object
     soundManager_ = new SoundInterfaceManager(maxSounds, parameters_);
+
+    // Add Sinusoidal Synth sound to synthesizer
+    BigInteger midiNotes;
+    midiNotes.setRange(0, 126, true);
+    synth_.addSound(new SinusoidalSynthSound(midiNotes, 69, 512, soundManager_));
     
     // Initial
     currentUISound_ = 0;

--- a/Source/PluginProcessor.cpp
+++ b/Source/PluginProcessor.cpp
@@ -32,6 +32,8 @@ LoomAudioProcessor::LoomAudioProcessor()
     // Allocate voices for synthesizer
     for (int i = 0; i < maxVoices; ++i)
         synth_.addVoice (new SinusoidalSynthVoice());
+
+    
     
     // Create the sound manager object
     soundManager_ = new SoundInterfaceManager(maxSounds, parameters_);

--- a/Source/PluginProcessor.cpp
+++ b/Source/PluginProcessor.cpp
@@ -31,6 +31,9 @@ LoomAudioProcessor::LoomAudioProcessor()
     for (int i = 0; i < maxVoices; ++i)
         synth_.addVoice (new SinusoidalSynthVoice());
     
+    // Create the sound manager object
+    soundManager_ = new SoundInterfaceManager;
+    
     currentSound_ = 0;
     
     AnalysisParameterManager* analysisParams;

--- a/Source/PluginProcessor.cpp
+++ b/Source/PluginProcessor.cpp
@@ -24,30 +24,22 @@ LoomAudioProcessor::LoomAudioProcessor()
                        )
 #endif
 {
+    // Parameters are managed in JUCE's AudioProcessorValueTreeState which also
+    // supports undo and redo
     undoManager_ = new UndoManager;
-    processorState_ = new AudioProcessorValueTreeState(*this, undoManager_);
+    parameters_ = new AudioProcessorValueTreeState(*this, undoManager_);
     
     // Allocate voices for synthesizer
     for (int i = 0; i < maxVoices; ++i)
         synth_.addVoice (new SinusoidalSynthVoice());
     
     // Create the sound manager object
-    soundManager_ = new SoundInterfaceManager;
+    soundManager_ = new SoundInterfaceManager(maxSounds, parameters_);
     
-    currentSound_ = 0;
+    // Initial
+    currentUISound_ = 0;
     
-    AnalysisParameterManager* analysisParams;
-    analysisParameters_.clear();
-    analysisParameters_.insert(
-        currentSound_,
-        analysisParams =  new AnalysisParameterManager(currentSound_, processorState_)
-    );
-    
-    // Instantiate an empty sound interface
-    sounds_.clear();
-    sounds_.insert(currentSound_, new SoundInterface(analysisParams));
-    
-    processorState_->state = ValueTree(Identifier("LOOM"));
+    parameters_->state = ValueTree(Identifier("LOOM"));
 }
 
 LoomAudioProcessor::~LoomAudioProcessor()
@@ -199,15 +191,9 @@ void LoomAudioProcessor::swapSound(const SoundInterface &newSound)
 {
 }
 
-
-SoundInterface& LoomAudioProcessor::getCurrentSound()
-{
-    return *sounds_[currentSound_];
-}
-
 AudioProcessorValueTreeState& LoomAudioProcessor::getParams()
 {
-    return *processorState_;
+    return *parameters_;
 }
 
 //==============================================================================

--- a/Source/PluginProcessor.cpp
+++ b/Source/PluginProcessor.cpp
@@ -189,21 +189,11 @@ void LoomAudioProcessor::setStateInformation (const void* data, int sizeInBytes)
 // Swap the sinusoidal model out
 void LoomAudioProcessor::swapModel(ScopedPointer<SineModel> newModel)
 {
-    synth_.clearSounds();
-    
-    BigInteger midiNotes;
-    midiNotes.setRange(0, 126, true);
-    synth_.addSound(new SinusoidalSynthSound(midiNotes, 69, *newModel, 512));
 }
 
 
 void LoomAudioProcessor::swapSound(const SoundInterface &newSound)
 {
-    synth_.clearSounds();
-
-    BigInteger midiNotes;
-    midiNotes.setRange(0, 126, true);
-    synth_.addSound(new SinusoidalSynthSound(midiNotes, 69, newSound.getSineModel(), 512));
 }
 
 

--- a/Source/PluginProcessor.h
+++ b/Source/PluginProcessor.h
@@ -14,6 +14,7 @@
 #include "../JuceLibraryCode/JuceHeader.h"
 #include "SinusoidalSynthSound.h"
 #include "SinusoidalSynthVoice.h"
+#include "SoundInterfaceManager.h"
 #include "SoundInterface.h"
 #include "AnalysisParameterManager.h"
 
@@ -76,6 +77,8 @@ public:
 private:
     //==============================================================================
     int currentSound_;
+    
+    ScopedPointer<SoundInterfaceManager> soundManager_;
     
     Synthesiser synth_;
     OwnedArray<SoundInterface> sounds_;

--- a/Source/PluginProcessor.h
+++ b/Source/PluginProcessor.h
@@ -27,7 +27,7 @@ class LoomAudioProcessor  : public AudioProcessor
 public:
     enum
     {
-        maxVoices = 8,
+        maxVoices = 4,
         maxSounds = 4
     };
     

--- a/Source/PluginProcessor.h
+++ b/Source/PluginProcessor.h
@@ -70,24 +70,24 @@ public:
     //==============================================================================
     void swapModel(ScopedPointer<SineModel> newModel);
     void swapSound(const SoundInterface& newSound);
-    SoundInterface& getCurrentSound();
+    
+    SoundInterface* getCurrentSound() { return soundManager_->getInterface(currentUISound_); };
     
     AudioProcessorValueTreeState& getParams();
 
 private:
     //==============================================================================
-    int currentSound_;
     
+    // Keep track of model currently showing on UI
+    int currentUISound_;
+
+    // Sound manager is responsible for all sound model and parameter management objects
     ScopedPointer<SoundInterfaceManager> soundManager_;
     
     Synthesiser synth_;
-    OwnedArray<SoundInterface> sounds_;
-    
-    // Parameter managers for analysis
-    OwnedArray<AnalysisParameterManager> analysisParameters_;
     
     ScopedPointer<UndoManager> undoManager_;
-    ScopedPointer<AudioProcessorValueTreeState> processorState_;
+    ScopedPointer<AudioProcessorValueTreeState> parameters_;
     
     
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR (LoomAudioProcessor)

--- a/Source/SineElement.cpp
+++ b/Source/SineElement.cpp
@@ -37,106 +37,13 @@ SineModel::SineModel() : _sampleRate(0.0), _frameSize(0)
     _sineModel = SineModel::SineMatrix();
 }
 
+
 SineModel::~SineModel()
 {
 }
+
 
 void SineModel::addFrame(std::vector<SineElement> newFrame)
 {
     _sineModel.emplace_back(newFrame);
 }
-
-SineModel getTestModel()
-{
-    mrs_natural hopSize = 128;
-    mrs_real rate = 44100.0;
-    
-    SineModel testModel;
-    testModel.setHopSize(hopSize);
-    testModel.setFrameSize(hopSize);
-    testModel.setSampleRate(rate);
-    
-    mrs_real freq = 440.0;
-    mrs_real phase = 0.0;
-    mrs_real phaseInc = (hopSize/rate)*freq*2*PI;
-    
-    
-    
-    for (int i = 0; i < 100; ++i)
-    {
-        SineElement newElement(440.0, -12.0, phase);
-        phase += phaseInc;
-        SineModel::SineFrame newFrame;
-        newFrame.push_back(newElement);
-        testModel.addFrame(newFrame);
-    }
-    
-    return testModel;
-}
-
-SineModel getSawModel()
-{
-    mrs_natural hopSize = 128;
-    mrs_real rate = 44100.0;
-    
-    SineModel testModel;
-    testModel.setHopSize(hopSize);
-    testModel.setFrameSize(hopSize);
-    testModel.setSampleRate(rate);
-    
-    ptree pt1;
-    read_xml("/Users/jshier/Development/Libraries/sms-tools/software/models_interface/output.xml", pt1);
-    
-    
-    BOOST_FOREACH( boost::property_tree::ptree::value_type const& node, pt1.get_child( "model.frames" ) )
-    {
-        boost::property_tree::ptree subtree = node.second;
-        SineModel::SineFrame newFrame;
-        
-        if( node.first == "frame" )
-        {
-            BOOST_FOREACH( boost::property_tree::ptree::value_type const& v, subtree.get_child( "sines" ) )
-            {
-                boost::property_tree::ptree subsubtree = v.second;
-
-                SineElement newSine;
-                if (v.first == "sine")
-                {
-                    BOOST_FOREACH( boost::property_tree::ptree::value_type const& t, subsubtree.get_child( "" ) )
-                    {
-
-                        auto label = t.first;
-                        if (label == "freq")
-                        {
-                            std::string value = subsubtree.get<std::string>( label );
-                            newSine.setFreq(std::stod(value));
-                        }
-                        else if (label == "amp")
-                        {
-                            std::string value = subsubtree.get<std::string>( label );
-                            newSine.setAmp(std::stod(value));
-                        }
-                        else if (label == "phase")
-                        {
-                            std::string value = subsubtree.get<std::string>( label );
-                            newSine.setPhase(std::stod(value));
-                        }
-                        else if (label == "track")
-                        {
-                            std::string value = subsubtree.get<std::string>( label );
-                            newSine.setTrack(std::stod(value));
-                        }
-                    }
-                }
-                
-                newFrame.push_back(newSine);
-
-            }
-            testModel.addFrame(newFrame);
-        }
-    }
-    return testModel;
-}
-
-
-

--- a/Source/SineElement.h
+++ b/Source/SineElement.h
@@ -46,13 +46,20 @@ private:
 };
 
 
-class SineModel
+class SineModel : public ReferenceCountedObject
 {
 public:
+    
+    // Useful types
     typedef std::vector<SineElement> SineFrame;
     typedef std::vector<std::vector<SineElement>> SineMatrix;
+    typedef ReferenceCountedObjectPtr<SineModel> Ptr;
+    typedef const ReferenceCountedObjectPtr<SineModel> ConstPtr;
     
+    // Constructor
     SineModel();
+    
+    // Destructor
     ~SineModel();
     
     // Setters
@@ -85,12 +92,5 @@ private:
     mrs_natural _frameSize;
     mrs_natural _hopSize;
 };
-
-
-// TESTING
-SineModel getTestModel();
-SineModel getSawModel();
-
-
 
 #endif  // SINEELEMENT_H_INCLUDED

--- a/Source/SinusoidalSynthSound.cpp
+++ b/Source/SinusoidalSynthSound.cpp
@@ -60,16 +60,22 @@ bool SinusoidalSynthSound::appliesToChannel (int /*midiChannel*/)
 bool SinusoidalSynthSound::getSignal(mrs_realvec& timeVec, mrs_real loc, int renderRate) const
 {
     Array<SoundInterface*> activeSounds = manager_->getActiveSounds();
+    if (activeSounds.size() < 1)
+    {
+        return false;
+    }
+    
+    SineModel::ConstPtr model = activeSounds[0]->getSineModel();
     
     // Get number of frames in the model return if there aren't any
-    int modelFrames = std::distance(_model.begin(), _model.end());
+    int modelFrames = std::distance(model->begin(), model->end());
     if (modelFrames < 1)
     {
         return false;
     }
     
     // Get the frame closest to the requested time
-    mrs_real requestedPos = (loc * _model.getSampleRate()) / _model.getFrameSize();
+    mrs_real requestedPos = (loc * model->getSampleRate()) / model->getFrameSize();
     int requestedFrame = std::round(requestedPos);
     
     // Out of frames from the model
@@ -79,7 +85,7 @@ bool SinusoidalSynthSound::getSignal(mrs_realvec& timeVec, mrs_real loc, int ren
     }
     
     // Constant reference to the frame at this point
-    const SineModel::SineFrame& frame = _model.getFrame(requestedFrame);
+    const SineModel::SineFrame& frame = model->getFrame(requestedFrame);
     
     std::vector<FFT::Complex> spectrum(_frameSize);
     std::vector<FFT::Complex> timeDomain(_frameSize);

--- a/Source/SinusoidalSynthSound.cpp
+++ b/Source/SinusoidalSynthSound.cpp
@@ -170,15 +170,3 @@ bool SinusoidalSynthSound::getSignal(mrs_realvec& timeVec, mrs_real loc, int ren
     return true;
 }
 
-
-void SinusoidalSynthSound::addModel(SineModel::ConstPtr newModel, int soundNum)
-{
-    sineModels_.set(soundNum, newModel);
-}
-
-
-void SinusoidalSynthSound::removeModel(int soundNum)
-{
-    sineModels_.remove(soundNum);
-}
-

--- a/Source/SinusoidalSynthSound.cpp
+++ b/Source/SinusoidalSynthSound.cpp
@@ -173,7 +173,7 @@ bool SinusoidalSynthSound::getSignal(mrs_realvec& timeVec, mrs_real loc, int ren
 
 void SinusoidalSynthSound::addModel(SineModel::ConstPtr newModel, int soundNum)
 {
-    sineModels_.set(soundNum, &newModel);
+    sineModels_.set(soundNum, newModel);
 }
 
 

--- a/Source/SinusoidalSynthSound.cpp
+++ b/Source/SinusoidalSynthSound.cpp
@@ -34,35 +34,6 @@ SinusoidalSynthSound::SinusoidalSynthSound(const BigInteger& notes, int midiNote
 };
 
 
-// Constructor with a new model
-SinusoidalSynthSound::SinusoidalSynthSound(const BigInteger& notes, int midiNoteForNormalPitch, const SineModel& model, int frameSize)
-:   _midiNotes(notes),
-    _midiRootNote(midiNoteForNormalPitch),
-    _model(model),
-    _frameSize(frameSize)
-{
-    // Create a Blackman Harris windowing for sampling
-    _bh1001.create(1001);
-    //SynthUtils::windowingFillBlackmanHarris(_bh1001);
-    for (int i = 0; i < 1001; ++i)
-    {
-        _bh1001(i) = SynthUtils::BHCONST.at(i);
-    }
-    
-    _nyquistBin = _frameSize/2;
-    
-    // Allocate memory for the complex signals
-    _spectrum.resize(_frameSize);
-    _timeSignal.resize(_frameSize);
-    
-    // Inverse FFT of frame size
-    _fftFunction = new FFT(std::log2(_frameSize), true);
-    
-    _synthWindow.create(_frameSize);
-    SynthUtils::createSynthesisWindow(_synthWindow, _frameSize/4);
-};
-
-
 // Destructor
 SinusoidalSynthSound::~SinusoidalSynthSound()
 {
@@ -200,18 +171,14 @@ bool SinusoidalSynthSound::getSignal(mrs_realvec& timeVec, mrs_real loc, int ren
 }
 
 
-void SinusoidalSynthSound::addModel(const SineModel* newModel, int soundNum)
+void SinusoidalSynthSound::addModel(SineModel::ConstPtr newModel, int soundNum)
 {
-    if (sineModels_.size() - 1 < soundNum)
-    {
-        sineModels_.resize(soundNum + 1);
-        sineModels_.at(soundNum) = newModel;
-    }
+    sineModels_.set(soundNum, &newModel);
 }
 
 
 void SinusoidalSynthSound::removeModel(int soundNum)
 {
-    sineModels_.at(soundNum) = nullptr;
+    sineModels_.remove(soundNum);
 }
 

--- a/Source/SinusoidalSynthSound.cpp
+++ b/Source/SinusoidalSynthSound.cpp
@@ -18,9 +18,12 @@ SinusoidalSynthSound::SinusoidalSynthSound(const BigInteger& notes, int midiNote
     frameSize_(frameSize),
     manager_(manager)
 {
-    // Create a Blackman Harris windowing for sampling
     bh1001_.create(1001);
-    SynthUtils::windowingFillBlackmanHarris(bh1001_);
+    //SynthUtils::windowingFillBlackmanHarris(_bh1001);
+    for (int i = 0; i < 1001; ++i)
+    {
+        bh1001_(i) = SynthUtils::BHCONST.at(i);
+    }
     
     _nyquistBin = frameSize_/2;
     

--- a/Source/SinusoidalSynthSound.cpp
+++ b/Source/SinusoidalSynthSound.cpp
@@ -13,27 +13,20 @@
 // Empty model constructor
 SinusoidalSynthSound::SinusoidalSynthSound(const BigInteger& notes, int midiNoteForNormalPitch,
                                            int frameSize, SoundInterfaceManager* manager)
-:   _midiNotes(notes),
-    _midiRootNote(midiNoteForNormalPitch),
+:   midiNotes_(notes),
+    midiRootNote_(midiNoteForNormalPitch),
     frameSize_(frameSize),
     manager_(manager)
 {
+
+    // Blackman Harris window for spectral synthesis
     bh1001_.create(1001);
-    //SynthUtils::windowingFillBlackmanHarris(_bh1001);
     for (int i = 0; i < 1001; ++i)
     {
         bh1001_(i) = SynthUtils::BHCONST.at(i);
     }
     
-    _nyquistBin = frameSize_/2;
-    
-    // Allocate memory for the complex signals
-    _spectrum.resize(frameSize_);
-    _timeSignal.resize(frameSize_);
-    
-    // Inverse FFT of frame size
-    _fftFunction = new FFT(std::log2(frameSize_), true);
-    
+    // Synthesis window for windowing time domain output of signal
     synthWindow_.create(frameSize_);
     SynthUtils::createSynthesisWindow(synthWindow_, frameSize_/4);
 };
@@ -48,139 +41,13 @@ SinusoidalSynthSound::~SinusoidalSynthSound()
 // Sound for note?
 bool SinusoidalSynthSound::appliesToNote (int midiNoteNumber)
 {
-    return _midiNotes [midiNoteNumber];
+    return midiNotes_ [midiNoteNumber];
 }
 
 
 // Sound for midi channel?
 bool SinusoidalSynthSound::appliesToChannel (int /*midiChannel*/)
 {
-    return true;
-}
-
-
-// Get signal: returns a time domain signal of the sine model at the requested location
-bool SinusoidalSynthSound::getSignal(mrs_realvec& timeVec, mrs_real loc, int renderRate) const
-{
-    
-    ReferenceCountedArray<SineModel> activeModels = getPlayingSineModels();
-    if (activeModels.size() < 1)
-    {
-        return false;
-    }
-    
-    SineModel::ConstPtr model = activeModels[0];
-    
-    // Get number of frames in the model return if there aren't any
-    int modelFrames = std::distance(model->begin(), model->end());
-    if (modelFrames < 1)
-    {
-        return false;
-    }
-    
-    // Get the frame closest to the requested time
-    mrs_real requestedPos = (loc * model->getSampleRate()) / model->getFrameSize();
-    int requestedFrame = std::round(requestedPos);
-    
-    // Out of frames from the model
-    if (modelFrames <= requestedFrame)
-    {
-        return false;
-    }
-    
-    // Constant reference to the frame at this point
-    const SineModel::SineFrame& frame = model->getFrame(requestedFrame);
-    
-    std::vector<FFT::Complex> spectrum(frameSize_);
-    std::vector<FFT::Complex> timeDomain(frameSize_);
-    
-    // Create the spectral signal
-    for (auto sine = frame.begin(); sine != frame.end(); ++sine)
-    {
-        mrs_real binLoc =  (sine->getFreq() / renderRate) * frameSize_;
-        mrs_natural binInt = std::round(binLoc);
-        mrs_real binRem = binInt - binLoc;
-        
-        // Convert the decibels back to magnitude
-        mrs_real mag = pow(10, sine->getAmp()/20);
-        mrs_real phase = sine->getPhase();
-        
-        // Going to make a 9 bin wide Blackman Harris window
-        if (binLoc >= 5 && binLoc < _nyquistBin-4)
-        {
-            for (int i = -4; i < 5; ++i)
-            {
-                spectrum.at(binInt + i).r += mag*bh1001_((int)((binRem+i)*100) + 501)*cos(phase);
-                spectrum.at(binInt + i).i += mag*bh1001_((int)((binRem+i)*100) + 501)*sin(phase);
-            }
-        }
-        // Some components will wrap around 0
-        else if (binLoc < 5 && binLoc > 0)
-        {
-            for (int i = -4; i < 5; ++i)
-            {
-                // Complex Conjugate wraps around DC bin
-                if ((binInt + i) < 0)
-                {
-                    spectrum.at(-1*(binInt + i)).r += mag*bh1001_((int)((binRem+i)*100) + 501)*cos(phase);
-                    spectrum.at(-1*(binInt + i)).i += -mag*bh1001_((int)((binRem+i)*100) + 501)*sin(phase);
-                }
-                // Real only at DC bin
-                else if ((binInt + i) == 0)
-                {
-                    spectrum.at(0).r += 2*mag*bh1001_((int)((binRem+i)*100) + 501)*cos(phase);
-                }
-                // Regular
-                else
-                {
-                    spectrum.at(binInt + i).r += mag*bh1001_((int)((binRem+i)*100) + 501)*cos(phase);
-                    spectrum.at(binInt + i).i += mag*bh1001_((int)((binRem+i)*100) + 501)*sin(phase);
-                }
-            }
-        }
-        // Wrap around the Nyquist bin
-        else if (binLoc < (_nyquistBin - 1) && binLoc >= (_nyquistBin-4))
-        {
-            for (int i = -4; i < 5; ++i)
-            {
-                // Complex Conjugate wraps nyquist bin
-                if ((binInt + i) > _nyquistBin)
-                {
-                    spectrum.at((binInt + i) - _nyquistBin).r +=
-                        mag*bh1001_((int)((binRem+i)*100) + 501)*cos(phase);
-                    spectrum.at((binInt + i) - _nyquistBin).i +=
-                        -mag*bh1001_((int)((binRem+i)*100) + 501)*sin(phase);
-                }
-                // Real only at Nyquist
-                else if ((binInt + i) == _nyquistBin)
-                {
-                    spectrum.at(_nyquistBin).r += 2*mag*bh1001_((int)((binRem+i)*100) + 501)*cos(phase);
-                }
-                // Regular
-                else
-                {
-                    spectrum.at(binInt + i).r += mag*bh1001_((int)((binRem+i)*100) + 501)*cos(phase);
-                    spectrum.at(binInt + i).i += mag*bh1001_((int)((binRem+i)*100) + 501)*sin(phase);
-                }
-            }
-        }
-    }
-
-    // Conjugate for bins above the nyquist frequency
-    for (int i = 1; i < _nyquistBin; ++i)
-    {
-        spectrum.at(_nyquistBin + i).r = spectrum.at(_nyquistBin - i).r;
-        spectrum.at(_nyquistBin + i).i = -spectrum.at(_nyquistBin - i).i;
-    }
-   
-    _fftFunction->perform(spectrum.data(), timeDomain.data());
-  
-    // Apply synthesis window & shift
-    for (int i = 0; i < frameSize_; ++i)
-    {
-        timeVec(i) = timeDomain.at((i + (frameSize_ / 2)) % frameSize_).r / frameSize_ * synthWindow_(i);
-    }
-    
     return true;
 }
 

--- a/Source/SinusoidalSynthSound.cpp
+++ b/Source/SinusoidalSynthSound.cpp
@@ -198,3 +198,20 @@ bool SinusoidalSynthSound::getSignal(mrs_realvec& timeVec, mrs_real loc, int ren
     
     return true;
 }
+
+
+void SinusoidalSynthSound::addModel(const SineModel* newModel, int soundNum)
+{
+    if (sineModels_.size() - 1 < soundNum)
+    {
+        sineModels_.resize(soundNum + 1);
+        sineModels_.at(soundNum) = newModel;
+    }
+}
+
+
+void SinusoidalSynthSound::removeModel(int soundNum)
+{
+    sineModels_.at(soundNum) = nullptr;
+}
+

--- a/Source/SinusoidalSynthSound.cpp
+++ b/Source/SinusoidalSynthSound.cpp
@@ -11,10 +11,12 @@
 #include "SinusoidalSynthSound.h"
 
 // Empty model constructor
-SinusoidalSynthSound::SinusoidalSynthSound(const BigInteger& notes, int midiNoteForNormalPitch, int frameSize)
+SinusoidalSynthSound::SinusoidalSynthSound(const BigInteger& notes, int midiNoteForNormalPitch,
+                                           int frameSize, SoundInterfaceManager* manager)
 :   _midiNotes(notes),
     _midiRootNote(midiNoteForNormalPitch),
-    _frameSize(frameSize)
+    _frameSize(frameSize),
+    manager_(manager)
 {
     // Create a Blackman Harris windowing for sampling
     _bh1001.create(1001);
@@ -57,6 +59,8 @@ bool SinusoidalSynthSound::appliesToChannel (int /*midiChannel*/)
 // Get signal: returns a time domain signal of the sine model at the requested location
 bool SinusoidalSynthSound::getSignal(mrs_realvec& timeVec, mrs_real loc, int renderRate) const
 {
+    Array<SoundInterface*> activeSounds = manager_->getActiveSounds();
+    
     // Get number of frames in the model return if there aren't any
     int modelFrames = std::distance(_model.begin(), _model.end());
     if (modelFrames < 1)

--- a/Source/SinusoidalSynthSound.h
+++ b/Source/SinusoidalSynthSound.h
@@ -41,10 +41,10 @@ public:
     ReferenceCountedArray<SineModel> getPlayingSineModels() const;
     
     // Sample the blackman harris window
-    mrs_real getBH(int index) { return bh1001_(index); };
+    mrs_real getBH(int index) const { return bh1001_(index); };
     
     // Sample the synthesis window function
-    mrs_real getSynthWindow(int index) { return synthWindow_(index); };
+    mrs_real getSynthWindow(int index) const { return synthWindow_(index); };
     
     
     

--- a/Source/SinusoidalSynthSound.h
+++ b/Source/SinusoidalSynthSound.h
@@ -23,7 +23,6 @@ class SinusoidalSynthSound : public SynthesiserSound
 public:
     
     SinusoidalSynthSound(const BigInteger& notes, int midiNoteForNormalPitch, int frameSize);
-    SinusoidalSynthSound(const BigInteger& notes, int midiNoteForNormalPitch, const SineModel&, int frameSize);
     
     ~SinusoidalSynthSound();
     
@@ -35,11 +34,8 @@ public:
     // Get a time domain frame at a requested time location
     bool getSignal(mrs_realvec&, mrs_real, int) const;
     
-    // Switch out the Sine Model being rendered
-    void replaceModel(SineModel& newModel) { _model = newModel; };
-    
     // Point to a new sinusoidal model to include in synthesis
-    void addModel(const SineModel* newModel, int soundNum);
+    void addModel(SineModel::ConstPtr, int soundNum);
     
     // Remove pointer to one of the sound models
     void removeModel(int soundNum);
@@ -66,7 +62,7 @@ private:
     std::vector<FFT::Complex> _timeSignal;
     
     // Sine models representing this sound
-    std::vector<const SineModel*> sineModels_;
+    ReferenceCountedArray<SineModel::ConstPtr> sineModels_;
     
     // Pointer to FFT class
     ScopedPointer<FFT> _fftFunction;

--- a/Source/SinusoidalSynthSound.h
+++ b/Source/SinusoidalSynthSound.h
@@ -34,9 +34,6 @@ public:
     
     const int& getFrameSize() const { return frameSize_; };
     
-    // Get a time domain frame at a requested time location
-    bool getSignal(mrs_realvec&, mrs_real, int) const;
-    
     // Get a reference to all playing sinusoid models
     ReferenceCountedArray<SineModel> getPlayingSineModels() const;
     
@@ -51,26 +48,11 @@ public:
 private:
     friend class SinusoidalSynthVoice;
     
-    // Reset all real and imaginary spectrum values to 0
-    void resetSpectrum();
-    
-    BigInteger _midiNotes;
-    int _midiRootNote;
-    
-    SineModel _model;
+    BigInteger midiNotes_;
+    int midiRootNote_;
+    int frameSize_;
     mrs_realvec bh1001_;
     mrs_realvec synthWindow_;
-
-    int frameSize_;
-    mrs_real _nyquistBin;
-    
-    // Signals for holding spectral and time domain signals
-    std::vector<FFT::Complex> _spectrum;
-    std::vector<FFT::Complex> _timeSignal;
-    
-    // Pointer to FFT class
-    ScopedPointer<FFT> _fftFunction;
-    
     SoundInterfaceManager* manager_;
     
     JUCE_LEAK_DETECTOR(SinusoidalSynthSound)

--- a/Source/SinusoidalSynthSound.h
+++ b/Source/SinusoidalSynthSound.h
@@ -16,13 +16,16 @@
 #include "marsyas/system/MarSystemManager.h"
 #include "SynthesisUtils.h"
 #include "SoundInterface.h"
+#include "SoundInterfaceManager.h"
 
 
 class SinusoidalSynthSound : public SynthesiserSound
 {
 public:
     
-    SinusoidalSynthSound(const BigInteger& notes, int midiNoteForNormalPitch, int frameSize);
+    // Constructor
+    SinusoidalSynthSound(const BigInteger& notes, int midiNoteForNormalPitch,
+                         int frameSize, SoundInterfaceManager* manager);
     
     ~SinusoidalSynthSound();
     
@@ -33,6 +36,9 @@ public:
     
     // Get a time domain frame at a requested time location
     bool getSignal(mrs_realvec&, mrs_real, int) const;
+    
+    // Get a reference to all playing sinusoid models
+    ReferenceCountedArray<SineModel> getPlayingSineModels();
     
 private:
     friend class SinusoidalSynthVoice;
@@ -56,6 +62,8 @@ private:
     
     // Pointer to FFT class
     ScopedPointer<FFT> _fftFunction;
+    
+    SoundInterfaceManager* manager_;
     
     JUCE_LEAK_DETECTOR(SinusoidalSynthSound)
 };

--- a/Source/SinusoidalSynthSound.h
+++ b/Source/SinusoidalSynthSound.h
@@ -15,6 +15,8 @@
 #include "SineElement.h"
 #include "marsyas/system/MarSystemManager.h"
 #include "SynthesisUtils.h"
+#include "SoundInterface.h"
+
 
 class SinusoidalSynthSound : public SynthesiserSound
 {
@@ -33,7 +35,15 @@ public:
     // Get a time domain frame at a requested time location
     bool getSignal(mrs_realvec&, mrs_real, int) const;
     
+    // Switch out the Sine Model being rendered
     void replaceModel(SineModel& newModel) { _model = newModel; };
+    
+    // Point to a new sinusoidal model to include in synthesis
+    void addModel(const SineModel* newModel, int soundNum);
+    
+    // Remove pointer to one of the sound models
+    void removeModel(int soundNum);
+    
     
 private:
     friend class SinusoidalSynthVoice;
@@ -54,6 +64,9 @@ private:
     // Signals for holding spectral and time domain signals
     std::vector<FFT::Complex> _spectrum;
     std::vector<FFT::Complex> _timeSignal;
+    
+    // Sine models representing this sound
+    std::vector<const SineModel*> sineModels_;
     
     // Pointer to FFT class
     ScopedPointer<FFT> _fftFunction;

--- a/Source/SinusoidalSynthSound.h
+++ b/Source/SinusoidalSynthSound.h
@@ -34,13 +34,6 @@ public:
     // Get a time domain frame at a requested time location
     bool getSignal(mrs_realvec&, mrs_real, int) const;
     
-    // Point to a new sinusoidal model to include in synthesis
-    void addModel(SineModel::ConstPtr, int soundNum);
-    
-    // Remove pointer to one of the sound models
-    void removeModel(int soundNum);
-    
-    
 private:
     friend class SinusoidalSynthVoice;
     
@@ -60,9 +53,6 @@ private:
     // Signals for holding spectral and time domain signals
     std::vector<FFT::Complex> _spectrum;
     std::vector<FFT::Complex> _timeSignal;
-    
-    // Sine models representing this sound
-    ReferenceCountedArray<SineModel> sineModels_;
     
     // Pointer to FFT class
     ScopedPointer<FFT> _fftFunction;

--- a/Source/SinusoidalSynthSound.h
+++ b/Source/SinusoidalSynthSound.h
@@ -62,7 +62,7 @@ private:
     std::vector<FFT::Complex> _timeSignal;
     
     // Sine models representing this sound
-    ReferenceCountedArray<SineModel::ConstPtr> sineModels_;
+    ReferenceCountedArray<SineModel> sineModels_;
     
     // Pointer to FFT class
     ScopedPointer<FFT> _fftFunction;

--- a/Source/SinusoidalSynthSound.h
+++ b/Source/SinusoidalSynthSound.h
@@ -32,13 +32,21 @@ public:
     bool appliesToNote (int midiNoteNumber) override;
     bool appliesToChannel (int midiChannel) override;
     
-    const int& getFrameSize() const { return _frameSize; };
+    const int& getFrameSize() const { return frameSize_; };
     
     // Get a time domain frame at a requested time location
     bool getSignal(mrs_realvec&, mrs_real, int) const;
     
     // Get a reference to all playing sinusoid models
-    ReferenceCountedArray<SineModel> getPlayingSineModels();
+    ReferenceCountedArray<SineModel> getPlayingSineModels() const;
+    
+    // Sample the blackman harris window
+    mrs_real getBH(int index) { return bh1001_(index); };
+    
+    // Sample the synthesis window function
+    mrs_real getSynthWindow(int index) { return synthWindow_(index); };
+    
+    
     
 private:
     friend class SinusoidalSynthVoice;
@@ -50,10 +58,10 @@ private:
     int _midiRootNote;
     
     SineModel _model;
-    mrs_realvec _bh1001;
-    mrs_realvec _synthWindow;
+    mrs_realvec bh1001_;
+    mrs_realvec synthWindow_;
 
-    int _frameSize;
+    int frameSize_;
     mrs_real _nyquistBin;
     
     // Signals for holding spectral and time domain signals

--- a/Source/SinusoidalSynthVoice.cpp
+++ b/Source/SinusoidalSynthVoice.cpp
@@ -98,7 +98,7 @@ void SinusoidalSynthVoice::renderNextBlock (AudioSampleBuffer& outputBuffer, int
                 // TODO: do we need allocate memory here?
                 mrs_realvec output(playingSound->getFrameSize());
                 
-                if (playingSound->getSignal(output, location_, getSampleRate()))
+                if (renderFrames(output, playingSound))
                 {
                     // Do overlap add
                     for (int i = 0; i < playingSound->getFrameSize(); ++i)
@@ -140,7 +140,7 @@ void SinusoidalSynthVoice::renderNextBlock (AudioSampleBuffer& outputBuffer, int
 }
 
 //==============================================================================
-bool SinusoidalSynthVoice::renderNextFrame(mrs_realvec &buffer, SinusoidalSynthSound* sound)
+bool SinusoidalSynthVoice::renderFrames(mrs_realvec &buffer, const SinusoidalSynthSound* const sound)
 {
     ReferenceCountedArray<SineModel> activeModels = sound->getPlayingSineModels();
     if (activeModels.size() < 1)
@@ -170,12 +170,14 @@ bool SinusoidalSynthVoice::renderNextFrame(mrs_realvec &buffer, SinusoidalSynthS
     // Constant reference to the frame at this point
     const SineModel::SineFrame& frame = model->getFrame(requestedFrame);
     
+    // TODO: Do we need to allocate memory here?
     std::vector<FFT::Complex> spectrum(frameSize_);
     std::vector<FFT::Complex> timeDomain(frameSize_);
     
     // Create the spectral signal
     for (auto sine = frame.begin(); sine != frame.end(); ++sine)
     {
+        // TODO: move variable declations out of loop!
         mrs_real binLoc =  (sine->getFreq() / getSampleRate()) * frameSize_;
         mrs_natural binInt = std::round(binLoc);
         mrs_real binRem = binInt - binLoc;

--- a/Source/SinusoidalSynthVoice.cpp
+++ b/Source/SinusoidalSynthVoice.cpp
@@ -91,6 +91,7 @@ void SinusoidalSynthVoice::renderNextBlock (AudioSampleBuffer& outputBuffer, int
             // Get a new frame
             if (_hopIndex >= _hopSize)
             {
+                // TODO: do we need allocate memory here?
                 mrs_realvec output(playingSound->getFrameSize());
                 
                 if (playingSound->getSignal(output, _location, getSampleRate()))
@@ -133,3 +134,10 @@ void SinusoidalSynthVoice::renderNextBlock (AudioSampleBuffer& outputBuffer, int
         }
     }
 }
+
+
+void SinusoidalSynthVoice::renderNextFrame(mrs_realvec &buffer)
+{
+    
+}
+

--- a/Source/SinusoidalSynthVoice.h
+++ b/Source/SinusoidalSynthVoice.h
@@ -40,21 +40,22 @@ public:
 
 private:
     
-    void renderNextFrame (mrs_realvec& buffer);
+    bool renderNextFrame (mrs_realvec& buffer, SinusoidalSynthSound* sound);
     
     
     //=============================================================================
-    // TODO: rename all class members correctly
-    int _hopSize;
-    int _hopIndex;
-    int _windowSize;
-    int _overlapIndex;
-    int _readPos;
-    int _writePos;
+    int hopSize_;
+    int frameSize_;
+    int hopIndex_;
+    int overlapIndex_;
+    int readPos_;
+    int writePos_;
+    int nyquistBin_;
     
-    mrs_real _location;
+    mrs_real location_;
+    mrs_realvec buffer_;
     
-    mrs_realvec _buffer;
+    ScopedPointer<FFT> inverseFFT_;
     
     
     JUCE_LEAK_DETECTOR (SinusoidalSynthVoice)

--- a/Source/SinusoidalSynthVoice.h
+++ b/Source/SinusoidalSynthVoice.h
@@ -39,7 +39,12 @@ public:
     void renderNextBlock (AudioSampleBuffer&, int startSample, int numSamples) override;
 
 private:
+    
+    void renderNextFrame (mrs_realvec& buffer);
+    
+    
     //=============================================================================
+    // TODO: rename all class members correctly
     int _hopSize;
     int _hopIndex;
     int _windowSize;

--- a/Source/SinusoidalSynthVoice.h
+++ b/Source/SinusoidalSynthVoice.h
@@ -40,7 +40,7 @@ public:
 
 private:
     
-    bool renderNextFrame (mrs_realvec& buffer, SinusoidalSynthSound* sound);
+    bool renderFrames (mrs_realvec& buffer, const SinusoidalSynthSound* const sound);
     
     
     //=============================================================================

--- a/Source/SinusoidalSynthVoice.h
+++ b/Source/SinusoidalSynthVoice.h
@@ -54,8 +54,11 @@ private:
     
     mrs_real location_;
     mrs_realvec buffer_;
+    mrs_realvec output_;
     
     ScopedPointer<FFT> inverseFFT_;
+    std::vector<FFT::Complex> spectrum_;
+    std::vector<FFT::Complex> timeDomain_;
     
     
     JUCE_LEAK_DETECTOR (SinusoidalSynthVoice)

--- a/Source/SoundInterface.cpp
+++ b/Source/SoundInterface.cpp
@@ -74,3 +74,17 @@ bool SoundInterface::willAcceptFile(const juce::String &fileName)
 {
     return fileLoader_.fileExtensionOkay(fileName);
 }
+
+
+void SoundInterface::checkModels()
+{
+    for (int i = sineModels_.size(); --i >= 0;)
+    {
+        SineModel::Ptr model(sineModels_.getUnchecked(i));
+        
+        if (model->getReferenceCount() == 2)
+        {
+            sineModels_.remove(i);
+        }
+    }
+}

--- a/Source/SoundInterface.cpp
+++ b/Source/SoundInterface.cpp
@@ -14,7 +14,8 @@
 SoundInterface::SoundInterface(AnalysisParameterManager* a) : analysis_(nullptr), state_(loadFileState)
 {
     analysisParams_ = a;
-    sineModel_ = new SineModel;
+    currentSineModel_ = new SineModel;
+    sineModels_.add(&currentSineModel_);
 }
 
 
@@ -33,7 +34,8 @@ void SoundInterface::runAnalysis()
 {
     if (analysis_ != nullptr)
     {
-        sineModel_ = analysis_->runAnalysis();
+        currentSineModel_ = analysis_->runAnalysis();
+        sineModels_.add(&currentSineModel_);
     }
 }
 

--- a/Source/SoundInterface.cpp
+++ b/Source/SoundInterface.cpp
@@ -16,6 +16,7 @@ SoundInterface::SoundInterface(AnalysisParameterManager* a) : analysis_(nullptr)
     analysisParams_ = a;
     currentSineModel_ = new SineModel;
     sineModels_.add(currentSineModel_);
+    isActive_ = false;
 }
 
 

--- a/Source/SoundInterface.cpp
+++ b/Source/SoundInterface.cpp
@@ -15,7 +15,7 @@ SoundInterface::SoundInterface(AnalysisParameterManager* a) : analysis_(nullptr)
 {
     analysisParams_ = a;
     currentSineModel_ = new SineModel;
-    sineModels_.add(&currentSineModel_);
+    sineModels_.add(currentSineModel_);
 }
 
 
@@ -35,7 +35,7 @@ void SoundInterface::runAnalysis()
     if (analysis_ != nullptr)
     {
         currentSineModel_ = analysis_->runAnalysis();
-        sineModels_.add(&currentSineModel_);
+        sineModels_.add(currentSineModel_);
     }
 }
 

--- a/Source/SoundInterface.cpp
+++ b/Source/SoundInterface.cpp
@@ -37,6 +37,7 @@ void SoundInterface::runAnalysis()
     {
         currentSineModel_ = analysis_->runAnalysis();
         sineModels_.add(currentSineModel_);
+        isActive_ = true;
     }
 }
 

--- a/Source/SoundInterface.h
+++ b/Source/SoundInterface.h
@@ -67,6 +67,9 @@ public:
     // Pre-load check to see if a filename looks okay
     bool willAcceptFile(const String& fileName);
     
+    // Whether or not this sound can be played
+    bool isActive() { return isActive_; };
+    
 private:
     
     ScopedPointer<AnalysisMrs> analysis_;
@@ -75,13 +78,14 @@ private:
     ReferenceCountedArray<SineModel> sineModels_;
     SineModel::Ptr currentSineModel_;
     
-    
     State state_;
     
     FileLoader fileLoader_;
     
     // Parameters for the analysis phase
     AnalysisParameterManager* analysisParams_;
+    
+    bool isActive_;
     
 };
 

--- a/Source/SoundInterface.h
+++ b/Source/SoundInterface.h
@@ -46,7 +46,7 @@ public:
     void runAnalysis();
     
     // Sine Model Getter
-    const SineModel& getSineModel() const { return *sineModel_; };
+    SineModel::ConstPtr getSineModel() const { return currentSineModel_; };
     
     // Get current state of sound
     State getState() const { return state_; };
@@ -54,8 +54,10 @@ public:
     // Set current state of sound
     void setState(State newState) { state_ = newState; };
     
+    // Get a parameter value from a parameter name
     float getParameterValue(String);
-    
+
+    // Get a pointer to the analysis parameters
     AnalysisParameterManager* getAnalysisParams() { return analysisParams_; };
     
     // Load audio from file and load into a new analysis object
@@ -68,7 +70,11 @@ public:
 private:
     
     ScopedPointer<AnalysisMrs> analysis_;
-    ScopedPointer<SineModel> sineModel_;
+    
+    // Reference counted pointers to Sine Models for this interface
+    ReferenceCountedArray<SineModel::Ptr> sineModels_;
+    SineModel::Ptr currentSineModel_;
+    
     
     State state_;
     

--- a/Source/SoundInterface.h
+++ b/Source/SoundInterface.h
@@ -70,6 +70,9 @@ public:
     // Whether or not this sound can be played
     bool isActive() { return isActive_; };
     
+    // Checks reference counted SineModels to see if any can be freed
+    void checkModels();
+    
 private:
     
     ScopedPointer<AnalysisMrs> analysis_;

--- a/Source/SoundInterface.h
+++ b/Source/SoundInterface.h
@@ -72,7 +72,7 @@ private:
     ScopedPointer<AnalysisMrs> analysis_;
     
     // Reference counted pointers to Sine Models for this interface
-    ReferenceCountedArray<SineModel::Ptr> sineModels_;
+    ReferenceCountedArray<SineModel> sineModels_;
     SineModel::Ptr currentSineModel_;
     
     

--- a/Source/SoundInterfaceManager.cpp
+++ b/Source/SoundInterfaceManager.cpp
@@ -14,7 +14,6 @@
 SoundInterfaceManager::SoundInterfaceManager(int numSounds, AudioProcessorValueTreeState* params) :
 Thread("SoundInterface Manager Thread")
 {
-    
     SoundInterface* sound;
     AnalysisParameterManager* analysisParams;
     
@@ -28,7 +27,6 @@ Thread("SoundInterface Manager Thread")
         sound = new SoundInterface(analysisParams);
         soundInterfaces_.insert(i, sound);
     }
-    
     
     startThread();
 }
@@ -47,5 +45,20 @@ void SoundInterfaceManager::run()
         // Check to see if there are resources that can be cleaned up, also,
         // perhaps the analysis can be run on this thread!
     }
+}
+
+
+Array<SoundInterface*> SoundInterfaceManager::getActiveSounds()
+{
+    Array<SoundInterface*> activeSounds;
+    for (int i = 0; i < soundInterfaces_.size(); i++)
+    {
+        if (soundInterfaces_[i]->isActive())
+        {
+            activeSounds.add(soundInterfaces_[i]);
+        }
+    }
+    
+    return activeSounds;
 }
 

--- a/Source/SoundInterfaceManager.cpp
+++ b/Source/SoundInterfaceManager.cpp
@@ -11,8 +11,25 @@
 #include "SoundInterfaceManager.h"
 
 
-SoundInterfaceManager::SoundInterfaceManager() : Thread("SoundInterface Manager Thread")
+SoundInterfaceManager::SoundInterfaceManager(int numSounds, AudioProcessorValueTreeState* params) :
+Thread("SoundInterface Manager Thread")
 {
+    
+    SoundInterface* sound;
+    AnalysisParameterManager* analysisParams;
+    
+    for (int i = 0; i < numSounds; i++)
+    {
+        // New set of analysis parameters
+        analysisParams = new AnalysisParameterManager(i, params);
+        analysisParameters_.insert(i, analysisParams);
+       
+        // New sound interface for this particular sound
+        sound = new SoundInterface(analysisParams);
+        soundInterfaces_.insert(i, sound);
+    }
+    
+    
     startThread();
 }
 

--- a/Source/SoundInterfaceManager.cpp
+++ b/Source/SoundInterfaceManager.cpp
@@ -44,6 +44,11 @@ void SoundInterfaceManager::run()
     {
         // Check to see if there are resources that can be cleaned up, also,
         // perhaps the analysis can be run on this thread!
+        for (int i = 0; i < soundInterfaces_.size(); i++)
+        {
+            soundInterfaces_.getUnchecked(i)->checkModels();
+        }
+        wait(500);
     }
 }
 

--- a/Source/SoundInterfaceManager.cpp
+++ b/Source/SoundInterfaceManager.cpp
@@ -1,0 +1,34 @@
+/*
+  ==============================================================================
+
+    SoundInterfaceManager.cpp
+    Created: 23 Mar 2017 10:26:01pm
+    Author:  Jordie Shier 
+
+  ==============================================================================
+*/
+
+#include "SoundInterfaceManager.h"
+
+
+SoundInterfaceManager::SoundInterfaceManager() : Thread("SoundInterface Manager Thread")
+{
+    startThread();
+}
+
+
+SoundInterfaceManager::~SoundInterfaceManager()
+{
+    stopThread(4000);
+}
+
+
+void SoundInterfaceManager::run()
+{
+    while(!threadShouldExit())
+    {
+        // Check to see if there are resources that can be cleaned up, also,
+        // perhaps the analysis can be run on this thread!
+    }
+}
+

--- a/Source/SoundInterfaceManager.h
+++ b/Source/SoundInterfaceManager.h
@@ -13,24 +13,30 @@
 
 #include "../JuceLibraryCode/JuceHeader.h"
 #include "SoundInterface.h"
+#include "AnalysisParameterManager.h"
+
 
 class SoundInterfaceManager : private Thread
 {
 public:
     
-    // Default Construcotr
-    SoundInterfaceManager();
+    // Constructor
+    SoundInterfaceManager(int numSounds, AudioProcessorValueTreeState* params);
     
     // Default Deconstructor
     ~SoundInterfaceManager();
+    
+    // Get Sound Interface
+    SoundInterface* getInterface(int num) { return soundInterfaces_[num]; }
 
 private:
     
     // Run the thread
     void run() override;
     
-    // SoundInterfaces being managed here
+    // Sound interfaces and analysis parameters being managed here
     OwnedArray<SoundInterface> soundInterfaces_;
+    OwnedArray<AnalysisParameterManager> analysisParameters_;
     
 
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(SoundInterfaceManager)

--- a/Source/SoundInterfaceManager.h
+++ b/Source/SoundInterfaceManager.h
@@ -1,0 +1,43 @@
+/*
+  ==============================================================================
+
+    SoundInterfaceManager.h
+    Created: 23 Mar 2017 10:26:01pm
+    Author:  Jordie Shier 
+
+  ==============================================================================
+*/
+
+#ifndef SOUNDINTERFACEMANAGER_H_INCLUDED
+#define SOUNDINTERFACEMANAGER_H_INCLUDED
+
+#include "../JuceLibraryCode/JuceHeader.h"
+#include "SoundInterface.h"
+
+class SoundInterfaceManager : private Thread
+{
+public:
+    
+    // Default Construcotr
+    SoundInterfaceManager();
+    
+    // Default Deconstructor
+    ~SoundInterfaceManager();
+
+private:
+    
+    // Run the thread
+    void run() override;
+    
+    // SoundInterfaces being managed here
+    OwnedArray<SoundInterface> soundInterfaces_;
+    
+
+    JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(SoundInterfaceManager)
+};
+
+
+
+
+
+#endif  // SOUNDINTERFACEMANAGER_H_INCLUDED

--- a/Source/SoundInterfaceManager.h
+++ b/Source/SoundInterfaceManager.h
@@ -28,6 +28,9 @@ public:
     
     // Get Sound Interface
     SoundInterface* getInterface(int num) { return soundInterfaces_[num]; }
+    
+    // Get an array of pointers to active sounds
+    Array<SoundInterface*> getActiveSounds();
 
 private:
     


### PR DESCRIPTION
- Moved FFT Synthesis Code into the Synthesis Voice
- Changed the SineModel objects to ReferenceCounted objects
- Added a SoundInterfaceManager object for managing all sound interfaces and the associated parameters
- SoundInterfaceManager will run a check on a background thread to delete any objects that aren't being referenced any more -- this is to avoid dangling pointers in the synthesis processing block
- Added in rough framework that will allow for layer sounds in the synthesis side
- Plugin UI will need a bit of reworking in order to support multi layers